### PR TITLE
Privatization

### DIFF
--- a/collaborapp/birthdays/views.py
+++ b/collaborapp/birthdays/views.py
@@ -1,7 +1,8 @@
 from django.shortcuts import render
+from collaborapp.decorators import group_required
 
-# Create your views here.
 
+@group_required('us')  # private page, only admins and members of 'us' can access it
 def show_card(request, birthday_person, age):
     template = str(birthday_person) + '/' + str(age) + '/card.html'
     return render(request, template)

--- a/collaborapp/collaborapp/decorators.py
+++ b/collaborapp/collaborapp/decorators.py
@@ -1,0 +1,11 @@
+from django.contrib.auth.decorators import user_passes_test
+
+
+def group_required(*group_names):
+    """Requires user membership in at least one of the groups passed in."""
+    def in_groups(u):
+        if u.is_authenticated:
+            if bool(u.groups.filter(name__in=group_names)) | u.is_superuser:
+                return True
+        return False
+    return user_passes_test(in_groups)

--- a/collaborapp/home/management/commands/group_check.py
+++ b/collaborapp/home/management/commands/group_check.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import Group, User
+
+
+class Command(BaseCommand):
+    help = "Check whether private 'us' group and relevant users 'sadie' and 'martin' exist."
+
+    def handle(self, *args, **kwargs):
+        try:
+            us = Group.objects.get(name='us')
+            us_group_exists = True
+        except:
+            us_group_exists = False
+
+        existing_users = dict()
+        for user in ('sadie', 'martin'):
+            try:
+                u = User.objects.get(username=user)
+                existing_users[user] = True
+            except:
+                existing_users[user] = False
+
+        if us_group_exists and existing_users['sadie'] and existing_users['martin']:
+            print('All is well. Group and users exist. If you added a user recently, you may have to delete the group.')
+        elif us_group_exists:
+            print('Group exists. Double-check usernames: ', existing_users)
+        elif existing_users['sadie'] and existing_users['martin']:
+            print("Users 'sadie' and 'martin' exist. Run 'group_us' to add them to the 'us' group.")
+        else:
+            print("Double-check usernames: ", existing_users)

--- a/collaborapp/home/management/commands/group_us.py
+++ b/collaborapp/home/management/commands/group_us.py
@@ -28,7 +28,6 @@ class Command(BaseCommand):
                 us.permissions.add(p)
                 us.save()
 
-            users_to_add = input(": ").split()
             for u in users_to_add:
                 try:
                     self.add_user_to_group(us, u)

--- a/collaborapp/home/management/commands/group_us.py
+++ b/collaborapp/home/management/commands/group_us.py
@@ -1,0 +1,36 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import Group, Permission, User
+
+
+class Command(BaseCommand):
+    help = "Create group 'us' with full permissions and add users."
+
+    @staticmethod
+    def add_user_to_group(group, username):
+        u = User.objects.get(username=username)
+        u.groups.add(group)
+        u.save()
+
+    def add_arguments(self, parser):
+        parser.add_argument('username',
+                            nargs='+',
+                            type=str,
+                            help="Add usernames to add to 'us' group, separated by whitespace")
+
+    def handle(self, *args, **kwargs):
+        users_to_add = kwargs['username']
+        us, created = Group.objects.get_or_create(name='us')
+
+        if created:
+            us.save()
+            permissions = Permission.objects.all()
+            for p in permissions:
+                us.permissions.add(p)
+                us.save()
+
+            users_to_add = input(": ").split()
+            for u in users_to_add:
+                try:
+                    self.add_user_to_group(us, u)
+                except:
+                    print("No user with username {}".format(u))

--- a/collaborapp/notes/views.py
+++ b/collaborapp/notes/views.py
@@ -1,10 +1,12 @@
 from django.shortcuts import render
 from notes.forms import NoteForm
 from django.contrib.auth.decorators import login_required
+from collaborapp.decorators import group_required
 from notes.models import Note
 
 
 @login_required(login_url='/login')
+@group_required('us')  # private page, only admins and members of 'us' can access it
 def home(request):
     notes = Note.objects.filter(author=request.user).order_by('-created')
 
@@ -22,4 +24,3 @@ def home(request):
     else:
         form = NoteForm()
     return render(request, 'home.html', {'form': form, 'notes': notes})
-


### PR DESCRIPTION
Restrict viewing of private apps to members of the 'us' group. Add`manage.py` script to assign users to that group.

First command performs simple checks to see whether the setup is as expected (=very rudimentary testing):

```bash
python manage.py group_check
```

Second command creates the 'us' group and assigns defined usernames to it. Members of that group can view private apps.

```bash
python manage.py group_us username1 usernameN
```